### PR TITLE
Add sysupgrade functionality

### DIFF
--- a/msm89xx/base-files/lib/preinit/79-format-rootfs-data
+++ b/msm89xx/base-files/lib/preinit/79-format-rootfs-data
@@ -11,11 +11,29 @@ has_valid_ext4() {
 	[ "$magic" = "ef53" ]
 }
 
+copy_backup() {
+	local mnt
+
+	mnt=$(mktemp -d)
+	mount -t ext4 "$1" "$mnt" 2>/dev/null || {
+		rmdir "$mnt"
+		return 0
+	}
+
+	if [ -f "$mnt/.overlay/sysupgrade.tgz" ]; then
+		mv "$mnt/.overlay/sysupgrade.tgz" /tmp/sysupgrade.tgz
+	fi
+
+	umount "$mnt"
+	rmdir "$mnt"
+}
+
 preinit_format_rootfs_data() {
 	[ -b "$ROOTFS_DATA" ] || return 0
 	
 	if has_valid_ext4 "$ROOTFS_DATA"; then
 		echo "rootfs_data: valid ext4 filesystem detected" > /dev/kmsg
+		copy_backup "$ROOTFS_DATA"
 		return 0
 	fi
 	

--- a/msm89xx/base-files/lib/preinit/79-format-rootfs-data
+++ b/msm89xx/base-files/lib/preinit/79-format-rootfs-data
@@ -11,29 +11,11 @@ has_valid_ext4() {
 	[ "$magic" = "ef53" ]
 }
 
-copy_backup() {
-	local mnt
-
-	mnt=$(mktemp -d)
-	mount -t ext4 "$1" "$mnt" 2>/dev/null || {
-		rmdir "$mnt"
-		return 0
-	}
-
-	if [ -f "$mnt/.overlay-sysupgrade.tgz" ]; then
-		mv "$mnt/.overlay-sysupgrade.tgz" /tmp/sysupgrade.tgz
-	fi
-
-	umount "$mnt"
-	rmdir "$mnt"
-}
-
 preinit_format_rootfs_data() {
 	[ -b "$ROOTFS_DATA" ] || return 0
 	
 	if has_valid_ext4 "$ROOTFS_DATA"; then
 		echo "rootfs_data: valid ext4 filesystem detected" > /dev/kmsg
-		copy_backup "$ROOTFS_DATA"
 		return 0
 	fi
 	

--- a/msm89xx/base-files/lib/preinit/79-format-rootfs-data
+++ b/msm89xx/base-files/lib/preinit/79-format-rootfs-data
@@ -20,8 +20,8 @@ copy_backup() {
 		return 0
 	}
 
-	if [ -f "$mnt/.overlay/sysupgrade.tgz" ]; then
-		mv "$mnt/.overlay/sysupgrade.tgz" /tmp/sysupgrade.tgz
+	if [ -f "$mnt/.overlay-sysupgrade.tgz" ]; then
+		mv "$mnt/.overlay-sysupgrade.tgz" /tmp/sysupgrade.tgz
 	fi
 
 	umount "$mnt"

--- a/msm89xx/base-files/lib/upgrade/platform.sh
+++ b/msm89xx/base-files/lib/upgrade/platform.sh
@@ -1,0 +1,90 @@
+#!/bin/sh
+# MSM8916 eMMC sysupgrade - kernel (Android boot image) + rootfs (squashfs)
+#
+# The sysupgrade bundle is a tar containing:
+#   boot   - Android boot image for the kernel
+#   rootfs - squashfs root filesystem
+
+REQUIRE_IMAGE_METADATA=1
+
+platform_check_image() {
+    local tar_file="$1"
+    local member
+
+    # Must be a tar archive
+    if ! tar -tf "$tar_file" > /tmp/sysupgrade-members 2>/dev/null; then
+        echo "sysupgrade: not a valid tar archive"
+        return 1
+    fi
+
+    # Must contain both 'boot' and 'rootfs' members
+    if ! grep -q '^boot$' /tmp/sysupgrade-members; then
+        echo "sysupgrade: missing 'boot' member in image"
+        return 1
+    fi
+    if ! grep -q '^rootfs$' /tmp/sysupgrade-members; then
+        echo "sysupgrade: missing 'rootfs' member in image"
+        return 1
+    fi
+
+    # Validate squashfs magic in the rootfs member
+    local magic
+    magic=$(tar -xOf "$tar_file" rootfs 2>/dev/null | dd bs=4 count=1 2>/dev/null | hexdump -v -n 4 -e '1/4 "%08x"')
+    case "$magic" in
+        73717368)
+            ;;
+        *)
+            echo "sysupgrade: rootfs member does not look like squashfs (magic: $magic)"
+            return 1
+            ;;
+    esac
+
+    return 0
+}
+
+platform_do_upgrade() {
+    local tar_file="$1"
+    local boot_part rootfs_part
+
+    # Locate partitions by GPT label
+    boot_part=$(find_mmc_part "boot")
+    rootfs_part=$(find_mmc_part "rootfs")
+
+    if [ -z "$boot_part" ]; then
+        echo "sysupgrade: cannot find 'boot' partition"
+        return 1
+    fi
+    if [ -z "$rootfs_part" ]; then
+        echo "sysupgrade: cannot find 'rootfs' partition"
+        return 1
+    fi
+
+    echo "sysupgrade: writing kernel to $boot_part"
+    tar -xOf "$tar_file" boot 2>/dev/null | \
+        dd of="$boot_part" bs=4096 conv=fsync
+
+    echo "sysupgrade: writing rootfs to $rootfs_part"
+    tar -xOf "$tar_file" rootfs 2>/dev/null | \
+        dd of="$rootfs_part" bs=4096 conv=fsync
+
+    sync
+}
+
+platform_copy_config() {
+    local overlay_part mnt
+
+    overlay_part=$(find_mmc_part "rootfs_data")
+    [ -z "$overlay_part" ] && return 0
+
+    mnt=$(mktemp -d)
+    mount -t ext4 "$overlay_part" "$mnt" 2>/dev/null || {
+        rmdir "$mnt"
+        return 0
+    }
+
+    mkdir -p "$mnt/.overlay"
+    cp -af "$UPGRADE_BACKUP" "$mnt/.overlay/sysupgrade.tgz" 2>/dev/null
+
+    umount "$mnt"
+    rmdir "$mnt"
+}

--- a/msm89xx/base-files/lib/upgrade/platform.sh
+++ b/msm89xx/base-files/lib/upgrade/platform.sh
@@ -44,20 +44,9 @@ platform_do_upgrade() {
     sync
 }
 
-platform_copy_config() {
-    local overlay_part mnt
+platform_pre_upgrade() {
+    rm -fr /overlay/upper/* /overlay/upper/.* 2>/dev/null
+    [ -f "$UPGRADE_BACKUP" ] && cp -f "$UPGRADE_BACKUP" "/overlay/upper/$BACKUP_FILE" 2>/dev/null
 
-    overlay_part=$(find_mmc_part "rootfs_data")
-    [ -z "$overlay_part" ] && return 0
-
-    mnt=$(mktemp -d)
-    mount -t ext4 "$overlay_part" "$mnt" 2>/dev/null || {
-        rmdir "$mnt"
-        return 0
-    }
-
-    cp -f "$UPGRADE_BACKUP" "$mnt/.overlay-sysupgrade.tgz" 2>/dev/null
-
-    umount "$mnt"
-    rmdir "$mnt"
+    return 0
 }

--- a/msm89xx/base-files/lib/upgrade/platform.sh
+++ b/msm89xx/base-files/lib/upgrade/platform.sh
@@ -1,43 +1,21 @@
 #!/bin/sh
 # MSM8916 eMMC sysupgrade - kernel (Android boot image) + rootfs (squashfs)
-#
-# The sysupgrade bundle is a tar containing:
-#   boot   - Android boot image for the kernel
-#   rootfs - squashfs root filesystem
 
+PART_NAME=firmware
 REQUIRE_IMAGE_METADATA=1
 
 platform_check_image() {
-    local tar_file="$1"
-    local member
+    local fw_image="$1"
+    local boardname="$(board_name | tr -d '-' | tr ',' '-')"
 
     # Must be a tar archive
-    if ! tar -tf "$tar_file" > /tmp/sysupgrade-members 2>/dev/null; then
-        echo "sysupgrade: not a valid tar archive"
-        return 1
-    fi
+    local control_len=$( (tar xf $fw_image sysupgrade-$boardname/CONTROL -O | wc -c) 2> /dev/null)
 
-    # Must contain both 'boot' and 'rootfs' members
-    if ! grep -q '^boot$' /tmp/sysupgrade-members; then
-        echo "sysupgrade: missing 'boot' member in image"
+    # check if valid sysupgrade tar archive
+    if [ "$control_len" = "0" ]; then
+        echo "Invalid sysupgrade file: $fw_image"
         return 1
     fi
-    if ! grep -q '^rootfs$' /tmp/sysupgrade-members; then
-        echo "sysupgrade: missing 'rootfs' member in image"
-        return 1
-    fi
-
-    # Validate squashfs magic in the rootfs member
-    local magic
-    magic=$(tar -xOf "$tar_file" rootfs 2>/dev/null | dd bs=4 count=1 2>/dev/null | hexdump -v -n 4 -e '1/4 "%08x"')
-    case "$magic" in
-        73717368)
-            ;;
-        *)
-            echo "sysupgrade: rootfs member does not look like squashfs (magic: $magic)"
-            return 1
-            ;;
-    esac
 
     return 0
 }
@@ -45,26 +23,22 @@ platform_check_image() {
 platform_do_upgrade() {
     local tar_file="$1"
     local boot_part rootfs_part
+    local board_dir=$(tar tf $tar_file | grep -m 1 '^sysupgrade-.*/$')
+    board_dir=${board_dir%/}
 
     # Locate partitions by GPT label
     boot_part=$(find_mmc_part "boot")
     rootfs_part=$(find_mmc_part "rootfs")
 
-    if [ -z "$boot_part" ]; then
-        echo "sysupgrade: cannot find 'boot' partition"
-        return 1
-    fi
-    if [ -z "$rootfs_part" ]; then
-        echo "sysupgrade: cannot find 'rootfs' partition"
-        return 1
-    fi
+    [ -z "$boot_part" ] && { echo "sysupgrade: cannot find 'boot' partition"; return 1; }
+    [ -z "$rootfs_part" ] && { echo "sysupgrade: cannot find 'rootfs' partition"; return 1; }
 
     echo "sysupgrade: writing kernel to $boot_part"
-    tar -xOf "$tar_file" boot 2>/dev/null | \
+    tar -xOf "$tar_file" ${board_dir}/kernel 2>/dev/null | \
         dd of="$boot_part" bs=4096 conv=fsync
 
     echo "sysupgrade: writing rootfs to $rootfs_part"
-    tar -xOf "$tar_file" rootfs 2>/dev/null | \
+    tar -xOf "$tar_file" ${board_dir}/root 2>/dev/null | \
         dd of="$rootfs_part" bs=4096 conv=fsync
 
     sync
@@ -82,8 +56,7 @@ platform_copy_config() {
         return 0
     }
 
-    mkdir -p "$mnt/.overlay"
-    cp -af "$UPGRADE_BACKUP" "$mnt/.overlay/sysupgrade.tgz" 2>/dev/null
+    cp -f "$UPGRADE_BACKUP" "$mnt/.overlay-sysupgrade.tgz" 2>/dev/null
 
     umount "$mnt"
     rmdir "$mnt"

--- a/msm89xx/base-files/lib/upgrade/platform.sh
+++ b/msm89xx/base-files/lib/upgrade/platform.sh
@@ -3,10 +3,15 @@
 
 PART_NAME=firmware
 REQUIRE_IMAGE_METADATA=1
+RAMFS_COPY_DATA="/lib/functions.sh /lib/upgrade/common.sh /lib/upgrade/fwtool.sh /lib/upgrade/luci-add-conffiles.sh /lib/upgrade/platform.sh /lib/upgrade/tar.sh"
 
 platform_check_image() {
     local fw_image="$1"
-    local boardname="$(board_name | tr -d '-' | tr ',' '-')"
+    local boardname
+    
+    read boardname </tmp/sysinfo/board_name
+    boardname=${boardname//-/}
+    boardname=${boardname//,/-}
 
     # Must be a tar archive
     local control_len=$( (tar xf $fw_image sysupgrade-$boardname/CONTROL -O | wc -c) 2> /dev/null)
@@ -47,6 +52,4 @@ platform_do_upgrade() {
 platform_pre_upgrade() {
     rm -fr /overlay/upper/* /overlay/upper/.* 2>/dev/null
     [ -f "$UPGRADE_BACKUP" ] && cp -f "$UPGRADE_BACKUP" "/overlay/upper/$BACKUP_FILE" 2>/dev/null
-
-    return 0
 }

--- a/msm89xx/image/Makefile
+++ b/msm89xx/image/Makefile
@@ -18,13 +18,25 @@ define Build/aboot-img
 	mv $@.new $@
 endef
 
+define Build/msm89xx-sysupgrade
+	rm -rf $@.sysupgrade-tmp
+	mkdir -p $@.sysupgrade-tmp
+	cp $(IMAGE_KERNEL) $@.sysupgrade-tmp/boot
+	cp $@ $@.sysupgrade-tmp/rootfs
+	cd $@.sysupgrade-tmp && \
+		tar -cf $@.new --owner=0 --group=0 boot rootfs
+	mv $@.new $@
+	rm -rf $@.sysupgrade-tmp
+endef
+
 ### Devices ###
 define Device/Default
 	PROFILES := Default
-	KERNEL = kernel-bin | gzip | append-dtb
-	IMAGES := boot.img system.img
+	KERNEL = kernel-bin | gzip | append-dtb | aboot-img
+	IMAGES := boot.img system.img sysupgrade.bin
 	IMAGE/boot.img := append-kernel | aboot-img | append-metadata
 	IMAGE/system.img := append-rootfs | append-metadata
+	IMAGE/sysupgrade.bin := append-rootfs | pad-rootfs | msm89xx-sysupgrade | append-metadata
 	DEVICE_DTS_DIR := $(DTS_DIR)/qcom
 	DEVICE_DTS = $$(SOC)-$(lastword $(subst _, ,$(1)))
 	CMDLINE := "earlycon console=ttyMSM0,115200 rw"

--- a/msm89xx/image/Makefile
+++ b/msm89xx/image/Makefile
@@ -18,17 +18,6 @@ define Build/aboot-img
 	mv $@.new $@
 endef
 
-define Build/msm89xx-sysupgrade
-	rm -rf $@.sysupgrade-tmp
-	mkdir -p $@.sysupgrade-tmp
-	cp $(IMAGE_KERNEL) $@.sysupgrade-tmp/boot
-	cp $@ $@.sysupgrade-tmp/rootfs
-	cd $@.sysupgrade-tmp && \
-		tar -cf $@.new --owner=0 --group=0 boot rootfs
-	mv $@.new $@
-	rm -rf $@.sysupgrade-tmp
-endef
-
 ### Devices ###
 define Device/Default
 	PROFILES := Default
@@ -36,7 +25,7 @@ define Device/Default
 	IMAGES := boot.img system.img sysupgrade.bin
 	IMAGE/boot.img := append-kernel | append-metadata
 	IMAGE/system.img := append-rootfs | append-metadata
-	IMAGE/sysupgrade.bin := append-rootfs | pad-rootfs | msm89xx-sysupgrade | append-metadata
+	IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
 	DEVICE_DTS_DIR := $(DTS_DIR)/qcom
 	DEVICE_DTS = $$(SOC)-$(lastword $(subst _, ,$(1)))
 	CMDLINE := "earlycon console=ttyMSM0,115200 rw"

--- a/msm89xx/image/Makefile
+++ b/msm89xx/image/Makefile
@@ -34,7 +34,7 @@ define Device/Default
 	PROFILES := Default
 	KERNEL = kernel-bin | gzip | append-dtb | aboot-img
 	IMAGES := boot.img system.img sysupgrade.bin
-	IMAGE/boot.img := append-kernel | aboot-img | append-metadata
+	IMAGE/boot.img := append-kernel | append-metadata
 	IMAGE/system.img := append-rootfs | append-metadata
 	IMAGE/sysupgrade.bin := append-rootfs | pad-rootfs | msm89xx-sysupgrade | append-metadata
 	DEVICE_DTS_DIR := $(DTS_DIR)/qcom

--- a/msm89xx/image/msm8916.mk
+++ b/msm89xx/image/msm8916.mk
@@ -32,6 +32,7 @@ define Device/yiming-uz801v3
   $(Device/msm8916)
   DEVICE_VENDOR := YiMing
   DEVICE_MODEL := uz801v3
+  SUPPORTED_DEVICES := yiming,uz801-v3
   FILESYSTEMS := squashfs
   DEVICE_PACKAGES := wpad-basic-wolfssl rmtfs uci-usb-gadget \
                      block-mount f2fs-tools \


### PR DESCRIPTION
Create sysupgrade.bin image and add required scripts for it to work.

Allows flashing existing live dongle without requiring USB connection.