### PR TITLE
Refactor power button and display to support multi-mode cycling with auto-reset and additional screens

### DIFF
--- a/packages/configs-mifi/files/rc.button.power
+++ b/packages/configs-mifi/files/rc.button.power
@@ -1,15 +1,17 @@
 #!/bin/sh
 
 # Power button handler:
-#   Short press  -> cycle display screens (default -> stats -> network -> wireguard -> wifi -> notes -> default)
-#   After 15s idle -> auto-reset to default screen (display-manager handles dim/off naturally)
-#   Hold 5s+      -> shutdown
+#   Dim/off + press -> wake to current screen only (no cycle)
+#   Bright  + press -> cycle display screens (default -> stats -> network -> wireguard -> wifi -> notes -> default)
+#   After 15s idle  -> auto-reset to default screen (display-manager handles dim/off naturally)
+#   Hold 5s+        -> shutdown
 
 [ "${ACTION}" = "released" ] || exit 0
 
 MODE_FILE="/tmp/display_mode"
 RESET_PID_FILE="/tmp/display_reset.pid"
 FIFO="/var/run/display.fifo"
+BACKLIGHT_PATH="/sys/class/backlight/backlight"
 NUM_MODES=6
 LONG_PRESS_SEC=5
 RESET_TIMEOUT=15
@@ -22,7 +24,49 @@ if [ "${SEEN:-0}" -ge "$LONG_PRESS_SEC" ]; then
     exit 0
 fi
 
-# Short press: cycle to next mode
+# Determine if display is awake (near-full brightness) or dim/off.
+# Threshold = 80% of max brightness to avoid edge cases.
+CURRENT_BRIGHTNESS=$(cat "$BACKLIGHT_PATH/brightness" 2>/dev/null || echo 0)
+MAX_BRIGHTNESS=$(cat "$BACKLIGHT_PATH/max_brightness" 2>/dev/null || echo 1785)
+WAKE_THRESHOLD=$((MAX_BRIGHTNESS * 4 / 5))
+
+schedule_reset() {
+    # Cancel any pending reset timer
+    if [ -f "$RESET_PID_FILE" ]; then
+        OLD_PID=$(cat "$RESET_PID_FILE" 2>/dev/null)
+        [ -n "$OLD_PID" ] && kill "$OLD_PID" 2>/dev/null
+        rm -f "$RESET_PID_FILE"
+    fi
+
+    # Schedule auto-reset back to default screen after timeout
+    (
+        sleep "$RESET_TIMEOUT"
+        echo "0" > "$MODE_FILE"
+        logger -t power "Auto-reset to default screen"
+        if [ -p "$FIFO" ]; then
+            echo "update" > "$FIFO"
+        else
+            /usr/bin/update-display 2>/dev/null
+        fi
+        rm -f "$RESET_PID_FILE"
+    ) &
+    echo $! > "$RESET_PID_FILE"
+}
+
+if [ "$CURRENT_BRIGHTNESS" -lt "$WAKE_THRESHOLD" ]; then
+    # Display dim/off: wake to current screen, do NOT cycle
+    CUR_MODE=$(cat "$MODE_FILE" 2>/dev/null || echo "0")
+    logger -t power "Short press: wake (mode $CUR_MODE)"
+    if [ -p "$FIFO" ]; then
+        echo "full" > "$FIFO"
+    else
+        /usr/bin/update-display 2>/dev/null
+    fi
+    schedule_reset
+    exit 0
+fi
+
+# Display already bright: cycle to next mode
 MODE=$(cat "$MODE_FILE" 2>/dev/null || echo "0")
 MODE=$(( (MODE + 1) % NUM_MODES ))
 echo "$MODE" > "$MODE_FILE"
@@ -36,25 +80,6 @@ else
     /usr/bin/update-display 2>/dev/null
 fi
 
-# Cancel any pending reset timer
-if [ -f "$RESET_PID_FILE" ]; then
-    OLD_PID=$(cat "$RESET_PID_FILE" 2>/dev/null)
-    [ -n "$OLD_PID" ] && kill "$OLD_PID" 2>/dev/null
-    rm -f "$RESET_PID_FILE"
-fi
-
-# Schedule auto-reset back to default screen after timeout
-(
-    sleep "$RESET_TIMEOUT"
-    echo "0" > "$MODE_FILE"
-    logger -t power "Auto-reset to default screen"
-    if [ -p "$FIFO" ]; then
-        echo "update" > "$FIFO"
-    else
-        /usr/bin/update-display 2>/dev/null
-    fi
-    rm -f "$RESET_PID_FILE"
-) &
-echo $! > "$RESET_PID_FILE"
+schedule_reset
 
 exit 0

--- a/packages/configs-mifi/files/rc.button.power
+++ b/packages/configs-mifi/files/rc.button.power
@@ -1,33 +1,60 @@
 #!/bin/sh
 
+# Power button handler:
+#   Short press  -> cycle display screens (default -> stats -> network -> wireguard -> wifi -> notes -> default)
+#   After 15s idle -> auto-reset to default screen (display-manager handles dim/off naturally)
+#   Hold 5s+      -> shutdown
+
 [ "${ACTION}" = "released" ] || exit 0
 
-# Double-click Shutdown
-# Works standalone or with display-manager
+MODE_FILE="/tmp/display_mode"
+RESET_PID_FILE="/tmp/display_reset.pid"
+FIFO="/var/run/display.fifo"
+NUM_MODES=6
+LONG_PRESS_SEC=5
+RESET_TIMEOUT=15
 
-# Hardcoded values
-lockfile="/tmp/toff.lock"
-delay=1
-
-shutdown() {
-    logger -t poweroff "Powering off..."
-
+# OpenWrt button hotplug provides SEEN = seconds button was held
+if [ "${SEEN:-0}" -ge "$LONG_PRESS_SEC" ]; then
+    logger -t power "Long press (${SEEN}s): shutdown"
     sync
     /sbin/poweroff
-}
-
-touch_lock() {
-    touch "$lockfile"
-    sleep $delay
-    rm -f "$lockfile"
-}
-
-if [ -e "$lockfile" ]; then
-    rm -f "$lockfile"
-    sleep $delay
-    shutdown
-else
-    touch_lock &
+    exit 0
 fi
+
+# Short press: cycle to next mode
+MODE=$(cat "$MODE_FILE" 2>/dev/null || echo "0")
+MODE=$(( (MODE + 1) % NUM_MODES ))
+echo "$MODE" > "$MODE_FILE"
+logger -t power "Short press: switched to screen mode $MODE"
+
+# Wake the display (resets dim/off timers in display-manager) + render new mode
+if [ -p "$FIFO" ]; then
+    echo "full" > "$FIFO"
+    echo "update" > "$FIFO"
+else
+    /usr/bin/update-display 2>/dev/null
+fi
+
+# Cancel any pending reset timer
+if [ -f "$RESET_PID_FILE" ]; then
+    OLD_PID=$(cat "$RESET_PID_FILE" 2>/dev/null)
+    [ -n "$OLD_PID" ] && kill "$OLD_PID" 2>/dev/null
+    rm -f "$RESET_PID_FILE"
+fi
+
+# Schedule auto-reset back to default screen after timeout
+(
+    sleep "$RESET_TIMEOUT"
+    echo "0" > "$MODE_FILE"
+    logger -t power "Auto-reset to default screen"
+    if [ -p "$FIFO" ]; then
+        echo "update" > "$FIFO"
+    else
+        /usr/bin/update-display 2>/dev/null
+    fi
+    rm -f "$RESET_PID_FILE"
+) &
+echo $! > "$RESET_PID_FILE"
 
 exit 0

--- a/packages/router-display/files/update-display.sh
+++ b/packages/router-display/files/update-display.sh
@@ -1,21 +1,19 @@
 #!/bin/sh
 # /usr/sbin/update-display
-# Optimized display update script - caches operator name (requires reboot to change SIM)
+# Multi-mode display update script
+# Mode selected via /tmp/display_mode (0=default, 1=stats, 2=network, 3=wireguard)
 
-# === BATTERY ===
+MODE_FILE="/tmp/display_mode"
+MODE=$(cat "$MODE_FILE" 2>/dev/null || echo "0")
+
+# === BATTERY (shared by all modes) ===
 BMS_PATH="/sys/class/power_supply/pm8916-bms-vm"
-
 VOLTAGE=$(cat "$BMS_PATH/voltage_now" 2>/dev/null)
 VMAX=$(cat "$BMS_PATH/voltage_max_design" 2>/dev/null)
 VMIN=$(cat "$BMS_PATH/voltage_min_design" 2>/dev/null)
-
-# Check charging status
 CHARGING_STATUS=$(cat "$BMS_PATH/status" 2>/dev/null)
 CHARGING_FLAG=""
-
-if [ "$CHARGING_STATUS" = "Charging" ]; then
-    CHARGING_FLAG="-c"
-fi
+[ "$CHARGING_STATUS" = "Charging" ] && CHARGING_FLAG="-c"
 
 if [ -n "$VOLTAGE" ] && [ -n "$VMAX" ] && [ -n "$VMIN" ]; then
     BATTERY=$(awk "BEGIN {pct = (($VOLTAGE - $VMIN) / ($VMAX - $VMIN)) * 100; if(pct < 0) pct=0; if(pct > 100) pct=100; printf \"%.0f\", pct}")
@@ -23,67 +21,224 @@ else
     BATTERY=100
 fi
 
-# === WiFi AP ===
-QR_FLAG=""
-if ip link show phy0-ap0 2>/dev/null | grep -q "state UP"; then
-    QR_FLAG="-q"
-fi
+# Helper: convert bytes to human-readable
+human_bytes() {
+    awk -v b="$1" 'BEGIN {split("B K M G T",u); s=1; while(b>=1024 && s<5){b/=1024; s++} printf "%.1f%s", b, u[s]}'
+}
 
-# === MODEM (OPTIMIZED - single mmcli call + operator cache) ===
-OPERATOR_CACHE="/tmp/modem_operator.cache"
-MODEM_IDX=$(mmcli -L 2>/dev/null | grep -oE 'Modem/[0-9]+' | head -1 | cut -d'/' -f2)
+case "$MODE" in
+    1)
+        # === SYSTEM STATS MODE ===
+        UPTIME=$(awk '{d=int($1/86400); h=int(($1%86400)/3600); m=int(($1%3600)/60); if(d>0) printf "%dd%dh", d, h; else if(h>0) printf "%dh%dm", h, m; else printf "%dm", m}' /proc/uptime)
+        RAM=$(free -m | awk '/^Mem:/ {printf "%d/%dM", $3, $2}')
+        LOAD=$(awk '{print $1}' /proc/loadavg)
+        TEMP_RAW=$(cat /sys/class/thermal/thermal_zone0/temp 2>/dev/null)
+        if [ -n "$TEMP_RAW" ]; then
+            TEMP="$((TEMP_RAW/1000))C"
+        else
+            TEMP="N/A"
+        fi
 
-if [ -n "$MODEM_IDX" ]; then
-    # Single mmcli call - cache all modem data
-    MODEM_DATA=$(mmcli -m "$MODEM_IDX" -K 2>/dev/null)
-    
-    # Try to get operator from cache first (SIM doesn't change without reboot)
-    if [ -f "$OPERATOR_CACHE" ]; then
-        OPERATOR=$(cat "$OPERATOR_CACHE")
-    else
-        # Cache miss - fetch operator from SIM
-        SIM_IDX=$(echo "$MODEM_DATA" | grep 'modem.generic.sim' | awk -F': ' '{print $2}' | grep -oE '[0-9]+$')
-        
-        if [ -n "$SIM_IDX" ]; then
-            OPERATOR=$(mmcli -i "$SIM_IDX" -K 2>/dev/null | grep 'sim.properties.operator-name' | awk -F': ' '{print $2}')
+        /usr/bin/router-display -m 1 $CHARGING_FLAG -b "$BATTERY" \
+            -U "$UPTIME" -R "$RAM" -L "$LOAD" -T "$TEMP" > /dev/fb0
+        ;;
+    2)
+        # === NETWORK MODE ===
+        # Find any modem/WAN interface that actually has an IPv4 address
+        WAN_IF=""
+        WAN_IP=""
+        for iface in wwan0 usb0 rmnet_data0 rmnet0 rmnet_ipa0 eth0; do
+            IP=$(ip -4 addr show dev "$iface" 2>/dev/null | awk '/inet / {print $2}' | cut -d/ -f1 | head -1)
+            if [ -n "$IP" ]; then
+                WAN_IF="$iface"
+                WAN_IP="$IP"
+                break
+            fi
+        done
+        [ -z "$WAN_IP" ] && WAN_IP="None"
+
+        SIGNAL=""
+        SIG=""
+        QUAL=""
+        MODEM_IDX=$(mmcli -L 2>/dev/null | grep -oE 'Modem/[0-9]+' | head -1 | cut -d'/' -f2)
+        if [ -n "$MODEM_IDX" ]; then
+            SIG=$(mmcli -m "$MODEM_IDX" --signal-get 2>/dev/null | grep -oE 'rssi: [-0-9.]+' | head -1 | awk '{print $2}')
+            if [ -n "$SIG" ]; then
+                # Strip decimals for compactness: -67.0 -> -67
+                SIG_INT=$(printf '%.0f' "$SIG" 2>/dev/null)
+                SIGNAL="${SIG_INT}dB"
+            else
+                QUAL=$(mmcli -m "$MODEM_IDX" -K 2>/dev/null | grep 'signal-quality.value' | awk -F': ' '{print $2}' | tr -d "'")
+                [ -n "$QUAL" ] && SIGNAL="${QUAL}%"
+            fi
         fi
-        
-        # Fallback: operator from network (use cached modem data)
-        if [ -z "$OPERATOR" ]; then
-            OPERATOR=$(echo "$MODEM_DATA" | grep 'modem.3gpp.operator-name' | awk -F': ' '{print $2}')
+
+        # Derive 0-4 signal bars from RSSI (dBm) or signal quality (%)
+        SIGNAL_BARS=$(awk -v s="$SIG" -v q="$QUAL" 'BEGIN {
+            if (s != "" && s+0 != 0) {
+                if (s+0 >= -65) print 4
+                else if (s+0 >= -75) print 3
+                else if (s+0 >= -85) print 2
+                else if (s+0 >= -95) print 1
+                else print 0
+            } else if (q != "") {
+                if (q+0 >= 75) print 4
+                else if (q+0 >= 50) print 3
+                else if (q+0 >= 25) print 2
+                else if (q+0 >= 10) print 1
+                else print 0
+            } else print 0
+        }')
+
+        RX_B=0
+        TX_B=0
+        if [ -n "$WAN_IF" ]; then
+            RX_B=$(cat /sys/class/net/$WAN_IF/statistics/rx_bytes 2>/dev/null || echo 0)
+            TX_B=$(cat /sys/class/net/$WAN_IF/statistics/tx_bytes 2>/dev/null || echo 0)
         fi
-        
-        # Cache operator for future calls
-        if [ -n "$OPERATOR" ]; then
-            echo "$OPERATOR" > "$OPERATOR_CACHE"
+        RX=$(human_bytes "$RX_B")
+        TX=$(human_bytes "$TX_B")
+
+        CLIENTS=$(iw dev phy0-ap0 station dump 2>/dev/null | grep -c "^Station")
+        [ -z "$CLIENTS" ] && CLIENTS=0
+
+        /usr/bin/router-display -m 2 $CHARGING_FLAG -b "$BATTERY" \
+            -I "$WAN_IP" -G "$SIGNAL" -g "$SIGNAL_BARS" \
+            -X "$RX" -Y "$TX" -C "$CLIENTS" > /dev/fb0
+        ;;
+    3)
+        # === WIREGUARD MODE ===
+        WG_IF=$(wg show interfaces 2>/dev/null | awk '{print $1}' | head -1)
+        WG_STATUS="Down"
+        WG_HS="Never"
+        WG_RX="0B"
+        WG_TX="0B"
+
+        if [ -n "$WG_IF" ]; then
+            HS_TS=$(wg show "$WG_IF" latest-handshakes 2>/dev/null | awk '{print $2}' | head -1)
+            if [ -n "$HS_TS" ] && [ "$HS_TS" != "0" ]; then
+                NOW=$(date +%s)
+                AGO=$((NOW - HS_TS))
+                if [ "$AGO" -lt 180 ]; then
+                    WG_STATUS="UP"
+                else
+                    WG_STATUS="Stale"
+                fi
+                if [ "$AGO" -lt 60 ]; then
+                    WG_HS="${AGO}s"
+                elif [ "$AGO" -lt 3600 ]; then
+                    WG_HS="$((AGO/60))m"
+                else
+                    WG_HS="$((AGO/3600))h"
+                fi
+            fi
+            TRANSFER=$(wg show "$WG_IF" transfer 2>/dev/null | head -1)
+            if [ -n "$TRANSFER" ]; then
+                RX_B=$(echo "$TRANSFER" | awk '{print $2}')
+                TX_B=$(echo "$TRANSFER" | awk '{print $3}')
+                WG_RX=$(human_bytes "$RX_B")
+                WG_TX=$(human_bytes "$TX_B")
+            fi
         fi
-    fi
-    
-    # Access technology (use cached modem data)
-    ACCESS_TECH=$(echo "$MODEM_DATA" | grep 'modem.generic.access-technologies' | awk -F': ' '{print $2}')
-    
-    # Determine network type only if connected
-    if [ -n "$ACCESS_TECH" ] && [ "$ACCESS_TECH" != "unknown" ]; then
-        case "$ACCESS_TECH" in
-            *lte*) NETWORK="4G" ;;
-            *umts*|*hspa*|*hsupa*|*hsdpa*) NETWORK="3G" ;;
-            *edge*|*gprs*|*gsm*) NETWORK="2G" ;;
-            *) NETWORK="$ACCESS_TECH" ;;
-        esac
-    else
-        # No connection: show operator but no network type
+
+        # System uptime (shown as "Up:" on the VPN screen)
+        SYS_UPTIME=$(awk '{d=int($1/86400); h=int(($1%86400)/3600); m=int(($1%3600)/60); if(d>0) printf "%dd%dh", d, h; else if(h>0) printf "%dh%dm", h, m; else printf "%dm", m}' /proc/uptime)
+
+        /usr/bin/router-display -m 3 $CHARGING_FLAG -b "$BATTERY" \
+            -W "$WG_STATUS" -H "$WG_HS" -a "$SYS_UPTIME" \
+            -D "$WG_RX" -E "$WG_TX" > /dev/fb0
+        ;;
+    4)
+        # === WIFI MODE ===
+        SSID=$(uci get wireless.@wifi-iface[0].ssid 2>/dev/null || echo "WiFi")
+        PASSWORD=$(uci get wireless.@wifi-iface[0].key 2>/dev/null || echo "(open)")
+        CLIENTS=$(iw dev phy0-ap0 station dump 2>/dev/null | grep -c "^Station")
+        [ -z "$CLIENTS" ] && CLIENTS=0
+
+        /usr/bin/router-display -m 4 $CHARGING_FLAG -b "$BATTERY" \
+            -s "$SSID" -p "$PASSWORD" -C "$CLIENTS" > /dev/fb0
+        ;;
+    5)
+        # === NOTES MODE ===
+        # Priority: UCI system.notes -> /etc/display_notes file -> system.description
+        NOTES=$(uci get system.@system[0].notes 2>/dev/null)
+        [ -z "$NOTES" ] && NOTES=$(cat /etc/display_notes 2>/dev/null)
+        [ -z "$NOTES" ] && NOTES=$(uci get system.@system[0].description 2>/dev/null)
+
+        /usr/bin/router-display -m 5 $CHARGING_FLAG -b "$BATTERY" \
+            -N "$NOTES" > /dev/fb0
+        ;;
+    *)
+        # === DEFAULT MODE (QR / operator / signal bars / battery) ===
+        QR_FLAG=""
+        if ip link show phy0-ap0 2>/dev/null | grep -q "state UP"; then
+            QR_FLAG="-q"
+        fi
+
+        OPERATOR_CACHE="/tmp/modem_operator.cache"
+        MODEM_IDX=$(mmcli -L 2>/dev/null | grep -oE 'Modem/[0-9]+' | head -1 | cut -d'/' -f2)
+
+        OPERATOR=""
         NETWORK=""
-    fi
-else
-    # No modem
-    OPERATOR=""
-    NETWORK=""
-fi
+        SIG=""
+        QUAL=""
+        if [ -n "$MODEM_IDX" ]; then
+            MODEM_DATA=$(mmcli -m "$MODEM_IDX" -K 2>/dev/null)
 
-# === WiFi Info ===
-SSID=$(uci get wireless.@wifi-iface[0].ssid 2>/dev/null || echo "WiFi")
-PASSWORD=$(uci get wireless.@wifi-iface[0].key 2>/dev/null || echo "")
-HOSTNAME=$(uci get system.@system[0].hostname 2>/dev/null || echo "Router")
+            if [ -f "$OPERATOR_CACHE" ]; then
+                OPERATOR=$(cat "$OPERATOR_CACHE")
+            else
+                SIM_IDX=$(echo "$MODEM_DATA" | grep 'modem.generic.sim' | awk -F': ' '{print $2}' | grep -oE '[0-9]+$')
+                if [ -n "$SIM_IDX" ]; then
+                    OPERATOR=$(mmcli -i "$SIM_IDX" -K 2>/dev/null | grep 'sim.properties.operator-name' | awk -F': ' '{print $2}')
+                fi
+                if [ -z "$OPERATOR" ]; then
+                    OPERATOR=$(echo "$MODEM_DATA" | grep 'modem.3gpp.operator-name' | awk -F': ' '{print $2}')
+                fi
+                if [ -n "$OPERATOR" ]; then
+                    echo "$OPERATOR" > "$OPERATOR_CACHE"
+                fi
+            fi
 
-# === Update Display ===
-/usr/bin/router-display $QR_FLAG $CHARGING_FLAG -b "$BATTERY" -n "$OPERATOR" -t "$NETWORK" -s "$SSID" -p "$PASSWORD" -h "$HOSTNAME" > /dev/fb0
+            ACCESS_TECH=$(echo "$MODEM_DATA" | grep 'modem.generic.access-technologies' | awk -F': ' '{print $2}')
+            if [ -n "$ACCESS_TECH" ] && [ "$ACCESS_TECH" != "unknown" ]; then
+                case "$ACCESS_TECH" in
+                    *lte*) NETWORK="4G" ;;
+                    *umts*|*hspa*|*hsupa*|*hsdpa*) NETWORK="3G" ;;
+                    *edge*|*gprs*|*gsm*) NETWORK="2G" ;;
+                    *) NETWORK="$ACCESS_TECH" ;;
+                esac
+            fi
+
+            # Signal for bars
+            SIG=$(mmcli -m "$MODEM_IDX" --signal-get 2>/dev/null | grep -oE 'rssi: [-0-9.]+' | head -1 | awk '{print $2}')
+            if [ -z "$SIG" ]; then
+                QUAL=$(echo "$MODEM_DATA" | grep 'signal-quality.value' | awk -F': ' '{print $2}' | tr -d "'")
+            fi
+        fi
+
+        SIGNAL_BARS=$(awk -v s="$SIG" -v q="$QUAL" 'BEGIN {
+            if (s != "" && s+0 != 0) {
+                if (s+0 >= -65) print 4
+                else if (s+0 >= -75) print 3
+                else if (s+0 >= -85) print 2
+                else if (s+0 >= -95) print 1
+                else print 0
+            } else if (q != "") {
+                if (q+0 >= 75) print 4
+                else if (q+0 >= 50) print 3
+                else if (q+0 >= 25) print 2
+                else if (q+0 >= 10) print 1
+                else print 0
+            } else print 0
+        }')
+
+        SSID=$(uci get wireless.@wifi-iface[0].ssid 2>/dev/null || echo "WiFi")
+        PASSWORD=$(uci get wireless.@wifi-iface[0].key 2>/dev/null || echo "")
+        HOSTNAME=$(uci get system.@system[0].hostname 2>/dev/null || echo "Router")
+
+        /usr/bin/router-display -m 0 $QR_FLAG $CHARGING_FLAG \
+            -b "$BATTERY" -n "$OPERATOR" -t "$NETWORK" -g "$SIGNAL_BARS" \
+            -s "$SSID" -p "$PASSWORD" -h "$HOSTNAME" > /dev/fb0
+        ;;
+esac

--- a/packages/router-display/files/update-display.sh
+++ b/packages/router-display/files/update-display.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # /usr/sbin/update-display
 # Multi-mode display update script
-# Mode selected via /tmp/display_mode (0=default, 1=stats, 2=network, 3=wireguard)
+# Mode selected via /tmp/display_mode (0=default, 1=stats, 2=network, 3=wireguard, 4=wifi, 5=notes)
 
 MODE_FILE="/tmp/display_mode"
 MODE=$(cat "$MODE_FILE" 2>/dev/null || echo "0")

--- a/packages/router-display/files/update-display.sh
+++ b/packages/router-display/files/update-display.sh
@@ -7,16 +7,49 @@ MODE_FILE="/tmp/display_mode"
 MODE=$(cat "$MODE_FILE" 2>/dev/null || echo "0")
 
 # === BATTERY (shared by all modes) ===
+# Voltage sourcing strategy:
+#   1. Prefer voltage_ocv (rested, accurate) if the kernel has sampled it
+#   2. Fallback: max of 5 rapid voltage_now reads — approximates rested voltage
+#      by catching brief lulls between radio transmissions (load sag compensation)
+# SOC computed via piecewise HV Li-ion (4.35V) discharge curve.
+# Charging detection prefers charger 'online' flag; falls back to BMS status.
 BMS_PATH="/sys/class/power_supply/pm8916-bms-vm"
-VOLTAGE=$(cat "$BMS_PATH/voltage_now" 2>/dev/null)
-VMAX=$(cat "$BMS_PATH/voltage_max_design" 2>/dev/null)
-VMIN=$(cat "$BMS_PATH/voltage_min_design" 2>/dev/null)
-CHARGING_STATUS=$(cat "$BMS_PATH/status" 2>/dev/null)
-CHARGING_FLAG=""
-[ "$CHARGING_STATUS" = "Charging" ] && CHARGING_FLAG="-c"
+CHG_PATH="/sys/class/power_supply/pm8916-lbc-chgr"
 
-if [ -n "$VOLTAGE" ] && [ -n "$VMAX" ] && [ -n "$VMIN" ]; then
-    BATTERY=$(awk "BEGIN {pct = (($VOLTAGE - $VMIN) / ($VMAX - $VMIN)) * 100; if(pct < 0) pct=0; if(pct > 100) pct=100; printf \"%.0f\", pct}")
+VOLTAGE=$(cat "$BMS_PATH/voltage_ocv" 2>/dev/null)
+if [ -z "$VOLTAGE" ] || [ "$VOLTAGE" = "0" ]; then
+    VOLTAGE=$(
+        for _ in 1 2 3 4 5; do
+            cat "$BMS_PATH/voltage_now" 2>/dev/null
+        done | sort -n | tail -1
+    )
+fi
+
+CHARGING_FLAG=""
+if [ "$(cat "$CHG_PATH/online" 2>/dev/null)" = "1" ]; then
+    CHARGING_FLAG="-c"
+elif [ "$(cat "$BMS_PATH/status" 2>/dev/null)" = "Charging" ]; then
+    CHARGING_FLAG="-c"
+fi
+
+if [ -n "$VOLTAGE" ] && [ "$VOLTAGE" != "0" ]; then
+    BATTERY=$(awk -v v="$VOLTAGE" 'BEGIN {
+        mv = v / 1000
+        if      (mv >= 4350) pct = 100
+        else if (mv >= 4250) pct = 90 + (mv - 4250) * 0.10
+        else if (mv >= 4150) pct = 80 + (mv - 4150) * 0.10
+        else if (mv >= 4050) pct = 65 + (mv - 4050) * 0.15
+        else if (mv >= 3950) pct = 50 + (mv - 3950) * 0.15
+        else if (mv >= 3850) pct = 35 + (mv - 3850) * 0.15
+        else if (mv >= 3750) pct = 20 + (mv - 3750) * 0.15
+        else if (mv >= 3650) pct = 10 + (mv - 3650) * 0.10
+        else if (mv >= 3500) pct =  3 + (mv - 3500) * 0.047
+        else if (mv >= 3400) pct =      (mv - 3400) * 0.03
+        else                 pct = 0
+        if (pct < 0)   pct = 0
+        if (pct > 100) pct = 100
+        printf "%.0f", pct
+    }')
 else
     BATTERY=100
 fi

--- a/packages/router-display/src/main.c
+++ b/packages/router-display/src/main.c
@@ -27,7 +27,7 @@ typedef struct {
 
 typedef struct {
     int battery;
-    int charging;        // NEW: charging flag
+    int charging;
     char operator[32];
     char network_type[8];
     char ssid[64];
@@ -35,6 +35,27 @@ typedef struct {
     char hostname[32];
     int show_qr;
     int uppercase;
+    int mode;                 // 0=default, 1=stats, 2=network, 3=wireguard
+    // Stats mode
+    char uptime[16];
+    char ram[16];
+    char load[16];
+    char temp[8];
+    // Network mode
+    char wan_ip[20];
+    char signal[12];
+    int signal_bars;          // 0-4 for visual bars
+    char rx[12];
+    char tx[12];
+    int clients;
+    // WireGuard mode
+    char wg_status[12];
+    char wg_handshake[12];
+    char wg_uptime[16];
+    char wg_rx[12];
+    char wg_tx[12];
+    // Notes mode
+    char notes[512];
 } DisplayConfig;
 
 void fb_init(Framebuffer *fb) {
@@ -44,6 +65,17 @@ void fb_init(Framebuffer *fb) {
 void fb_put_pixel(Framebuffer *fb, int x, int y, uint16_t color) {
     if (x >= 0 && x < WIDTH && y >= 0 && y < HEIGHT) {
         fb->data[y * WIDTH + x] = color;
+    }
+}
+
+void fb_rotate_180(Framebuffer *fb) {
+    uint16_t temp[WIDTH * HEIGHT];
+    memcpy(temp, fb->data, sizeof(fb->data));
+    
+    for (int y = 0; y < HEIGHT; y++) {
+        for (int x = 0; x < WIDTH; x++) {
+            fb->data[y * WIDTH + x] = temp[(HEIGHT - 1 - y) * WIDTH + (WIDTH - 1 - x)];
+        }
     }
 }
 
@@ -168,55 +200,335 @@ void str_to_upper(char *str) {
     }
 }
 
+// Forward declarations for icon helpers (defined later in the file).
+static void draw_signal_bars(Framebuffer *fb, int x, int y_bottom, int bars);
+static void draw_battery_corner(Framebuffer *fb, FT_Face face, DisplayConfig *cfg);
+
+// Truncate `text` in-place with ".." suffix so it fits within max_width pixels.
+static void truncate_to_width(FT_Face face, char *text, size_t bufsz, int max_width, int fontsz) {
+    if (fb_get_text_width(face, text, fontsz) <= max_width) return;
+
+    int len = (int)strlen(text);
+    char buf[64];
+    while (len > 0) {
+        if (len + 2 >= (int)sizeof(buf)) { len--; continue; }
+        memcpy(buf, text, len);
+        buf[len] = '.';
+        buf[len + 1] = '.';
+        buf[len + 2] = '\0';
+        if (fb_get_text_width(face, buf, fontsz) <= max_width) {
+            strncpy(text, buf, bufsz - 1);
+            text[bufsz - 1] = '\0';
+            return;
+        }
+        len--;
+    }
+    text[0] = '\0';
+}
+
 void generate_display(Framebuffer *fb, DisplayConfig *cfg, FT_Face face) {
     fb_init(fb);
-    
+
     char operator_text[32], network_text[8], hostname_text[32];
-    strncpy(operator_text, cfg->operator, 31);
-    strncpy(network_text, cfg->network_type, 7);
-    strncpy(hostname_text, cfg->hostname, 31);
-    
+    strncpy(operator_text, cfg->operator, sizeof(operator_text) - 1);
+    operator_text[sizeof(operator_text) - 1] = '\0';
+    strncpy(network_text, cfg->network_type, sizeof(network_text) - 1);
+    network_text[sizeof(network_text) - 1] = '\0';
+    strncpy(hostname_text, cfg->hostname, sizeof(hostname_text) - 1);
+    hostname_text[sizeof(hostname_text) - 1] = '\0';
+
     if (cfg->uppercase) {
         str_to_upper(operator_text);
         str_to_upper(network_text);
         str_to_upper(hostname_text);
     }
-    
+
     // Calculate QR position: centered horizontally, at top with margin
     int qr_x = (WIDTH - QR_SIZE) / 2;
     int qr_y = QR_TOP_MARGIN;
-    
+
     if (cfg->show_qr) {
         char wifi_qr[256];
-        snprintf(wifi_qr, sizeof(wifi_qr), 
+        snprintf(wifi_qr, sizeof(wifi_qr),
                  "WIFI:T:WPA;S:%s;P:%s;;", cfg->ssid, cfg->password);
-        
-        // Try to draw QR, if it doesn't fit (returns 0), screen stays black
         fb_draw_qr(fb, wifi_qr, qr_x, qr_y, QR_SIZE);
     }
-    // If no QR or QR too large: stay black (fb_init already cleared to black)
-    
+
     int fontsz = 12;
     int line1_y = HEIGHT - fontsz - 3;
     int line2_y = HEIGHT - 3;
-    
-    fb_draw_text(fb, face, operator_text, 2, line1_y, fontsz);
-    
+
+    // --- Top row: [signal bars] [operator]                            [4G] ---
+    int bars_x = 2;
+    int bars_w = 11;   // 4 bars * 2px + 3 gaps of 1
+    draw_signal_bars(fb, bars_x, line1_y, cfg->signal_bars);
+
     int net_width = fb_get_text_width(face, network_text, fontsz);
+    int op_x = bars_x + bars_w + 3;
+    int op_max_w = WIDTH - op_x - net_width - 4;
+    truncate_to_width(face, operator_text, sizeof(operator_text), op_max_w, fontsz);
+    fb_draw_text(fb, face, operator_text, op_x, line1_y, fontsz);
+
     fb_draw_text(fb, face, network_text, WIDTH - net_width - 2, line1_y, fontsz);
-    
+
+    // --- Bottom row: [hostname]                                    [battery] ---
+    // Compute battery block width so we can truncate hostname if it collides.
+    char battery_text[8];
+    snprintf(battery_text, sizeof(battery_text), "%d%%", cfg->battery);
+    int bat_text_w = fb_get_text_width(face, battery_text, 11);
+    int bat_block_w = bat_text_w + 2 + 16;   // text + gap + icon
+    int host_max_w = WIDTH - 2 - bat_block_w - 4;
+    truncate_to_width(face, hostname_text, sizeof(hostname_text), host_max_w, fontsz);
     fb_draw_text(fb, face, hostname_text, 2, line2_y, fontsz);
-    
-    // NEW: Format battery with charging indicator
-    char battery_text[16];
-    if (cfg->charging) {
-        snprintf(battery_text, sizeof(battery_text), "+%d%%", cfg->battery);
-    } else {
-        snprintf(battery_text, sizeof(battery_text), "%d%%", cfg->battery);
+
+    draw_battery_corner(fb, face, cfg);
+}
+
+static void fb_draw_rect_outline(Framebuffer *fb, int x, int y, int w, int h, uint16_t color) {
+    for (int i = 0; i < w; i++) {
+        fb_put_pixel(fb, x + i, y, color);
+        fb_put_pixel(fb, x + i, y + h - 1, color);
     }
-    
-    int battery_width = fb_get_text_width(face, battery_text, fontsz);
-    fb_draw_text(fb, face, battery_text, WIDTH - battery_width - 2, line2_y, fontsz);
+    for (int i = 0; i < h; i++) {
+        fb_put_pixel(fb, x, y + i, color);
+        fb_put_pixel(fb, x + w - 1, y + i, color);
+    }
+}
+
+static void draw_battery_icon(Framebuffer *fb, int x, int y, int pct, int charging) {
+    // 14x7 body outline + 2x3 cap on the right
+    uint16_t white = 0xFFFF;
+    fb_draw_rect_outline(fb, x, y, 14, 7, white);
+    fb_draw_rect(fb, x + 14, y + 2, 2, 3, white);
+
+    // Fill proportional to pct (inner area = 12x5)
+    int fill_w = (pct * 12) / 100;
+    if (fill_w > 0) {
+        uint16_t color;
+        if (pct > 50)      color = RGB565(50, 220, 50);   // green
+        else if (pct > 20) color = RGB565(255, 200, 0);   // yellow
+        else               color = RGB565(255, 60, 60);   // red
+        fb_draw_rect(fb, x + 1, y + 1, fill_w, 5, color);
+    }
+
+    // Charging: draw a small lightning bolt overlay
+    if (charging) {
+        uint16_t bolt = RGB565(255, 255, 0);
+        int bx = x + 5, by = y + 1;
+        // Simple zig-zag bolt
+        fb_put_pixel(fb, bx + 2, by + 0, bolt);
+        fb_put_pixel(fb, bx + 1, by + 1, bolt);
+        fb_put_pixel(fb, bx + 2, by + 1, bolt);
+        fb_put_pixel(fb, bx + 0, by + 2, bolt);
+        fb_put_pixel(fb, bx + 1, by + 2, bolt);
+        fb_put_pixel(fb, bx + 2, by + 2, bolt);
+        fb_put_pixel(fb, bx + 3, by + 2, bolt);
+        fb_put_pixel(fb, bx + 2, by + 3, bolt);
+        fb_put_pixel(fb, bx + 3, by + 3, bolt);
+        fb_put_pixel(fb, bx + 3, by + 4, bolt);
+        fb_put_pixel(fb, bx + 2, by + 5, bolt);
+    }
+}
+
+static void draw_signal_bars(Framebuffer *fb, int x, int y_bottom, int bars) {
+    // 4 bars of width 2, heights 3/6/9/12, gap 1
+    uint16_t on = 0xFFFF;
+    uint16_t off = RGB565(70, 70, 70);
+    int heights[4] = {3, 6, 9, 12};
+    int cur_x = x;
+    for (int i = 0; i < 4; i++) {
+        uint16_t c = (i < bars) ? on : off;
+        fb_draw_rect(fb, cur_x, y_bottom - heights[i], 2, heights[i], c);
+        cur_x += 3;
+    }
+}
+
+static void draw_battery_corner(Framebuffer *fb, FT_Face face, DisplayConfig *cfg) {
+    char battery_text[8];
+    snprintf(battery_text, sizeof(battery_text), "%d%%", cfg->battery);
+    int tw = fb_get_text_width(face, battery_text, 11);
+    int icon_w = 16;  // 14 body + 2 cap
+    int gap = 2;
+    int total_w = tw + gap + icon_w;
+    int text_x = WIDTH - total_w - 2;
+    int icon_x = text_x + tw + gap;
+    int baseline_y = HEIGHT - 3;
+    int icon_y = HEIGHT - 9;
+
+    draw_battery_icon(fb, icon_x, icon_y, cfg->battery, cfg->charging);
+    fb_draw_text(fb, face, battery_text, text_x, baseline_y, 11);
+}
+
+void generate_stats_display(Framebuffer *fb, DisplayConfig *cfg, FT_Face face) {
+    fb_init(fb);
+    char line[64];
+    int y = 16;
+
+    fb_draw_text(fb, face, "SYSTEM", 2, y, 14); y += 22;
+    snprintf(line, sizeof(line), "Up:%s", cfg->uptime);
+    fb_draw_text(fb, face, line, 2, y, 11); y += 16;
+    snprintf(line, sizeof(line), "Load:%s", cfg->load);
+    fb_draw_text(fb, face, line, 2, y, 11); y += 16;
+    snprintf(line, sizeof(line), "RAM:%s", cfg->ram);
+    fb_draw_text(fb, face, line, 2, y, 11); y += 16;
+    snprintf(line, sizeof(line), "Temp:%s", cfg->temp);
+    fb_draw_text(fb, face, line, 2, y, 11);
+
+    draw_battery_corner(fb, face, cfg);
+}
+
+void generate_network_display(Framebuffer *fb, DisplayConfig *cfg, FT_Face face) {
+    fb_init(fb);
+    char line[64];
+    int y = 16;
+
+    fb_draw_text(fb, face, "NETWORK", 2, y, 14); y += 22;
+    snprintf(line, sizeof(line), "IP:%s", cfg->wan_ip);
+    fb_draw_text(fb, face, line, 2, y, 10); y += 16;
+
+    // Signal: "Sig:" label + bars icon + dB/% text
+    fb_draw_text(fb, face, "Sig:", 2, y, 11);
+    draw_signal_bars(fb, 28, y, cfg->signal_bars);
+    if (cfg->signal[0] != '\0') {
+        fb_draw_text(fb, face, cfg->signal, 44, y, 10);
+    }
+    y += 16;
+
+    snprintf(line, sizeof(line), "DL:%s", cfg->rx);
+    fb_draw_text(fb, face, line, 2, y, 11); y += 16;
+    snprintf(line, sizeof(line), "UL:%s  Cl:%d", cfg->tx, cfg->clients);
+    fb_draw_text(fb, face, line, 2, y, 11);
+
+    draw_battery_corner(fb, face, cfg);
+}
+
+void generate_wireguard_display(Framebuffer *fb, DisplayConfig *cfg, FT_Face face) {
+    fb_init(fb);
+    char line[64];
+    int y = 16;
+
+    fb_draw_text(fb, face, "VPN", 2, y, 14); y += 22;
+    snprintf(line, sizeof(line), "WG:%s", cfg->wg_status);
+    fb_draw_text(fb, face, line, 2, y, 12); y += 16;
+    snprintf(line, sizeof(line), "HS:%s", cfg->wg_handshake);
+    fb_draw_text(fb, face, line, 2, y, 11); y += 14;
+    snprintf(line, sizeof(line), "Up:%s", cfg->wg_uptime);
+    fb_draw_text(fb, face, line, 2, y, 11); y += 14;
+    snprintf(line, sizeof(line), "DL:%s", cfg->wg_rx);
+    fb_draw_text(fb, face, line, 2, y, 11); y += 14;
+    snprintf(line, sizeof(line), "UL:%s", cfg->wg_tx);
+    fb_draw_text(fb, face, line, 2, y, 11);
+
+    draw_battery_corner(fb, face, cfg);
+}
+
+void generate_wifi_display(Framebuffer *fb, DisplayConfig *cfg, FT_Face face) {
+    fb_init(fb);
+    char line[96];
+    int y = 16;
+
+    fb_draw_text(fb, face, "WIFI", 2, y, 14); y += 22;
+
+    fb_draw_text(fb, face, "SSID:", 2, y, 11); y += 14;
+    // Auto-shrink font if SSID is long
+    int fs = 12;
+    if (fb_get_text_width(face, cfg->ssid, fs) > WIDTH - 4) fs = 10;
+    if (fb_get_text_width(face, cfg->ssid, fs) > WIDTH - 4) fs = 9;
+    fb_draw_text(fb, face, cfg->ssid, 2, y, fs); y += 16;
+
+    fb_draw_text(fb, face, "Pass:", 2, y, 11); y += 14;
+    fs = 12;
+    if (fb_get_text_width(face, cfg->password, fs) > WIDTH - 4) fs = 10;
+    if (fb_get_text_width(face, cfg->password, fs) > WIDTH - 4) fs = 9;
+    fb_draw_text(fb, face, cfg->password, 2, y, fs); y += 16;
+
+    snprintf(line, sizeof(line), "Clients: %d", cfg->clients);
+    fb_draw_text(fb, face, line, 2, y, 11);
+
+    draw_battery_corner(fb, face, cfg);
+}
+
+// Word-wrap + render text in a bounded region.
+// Explicit newlines (\n) are honored. max_lines prevents overflow.
+static void fb_draw_wrapped_text(Framebuffer *fb, FT_Face face, const char *text,
+                                  int x, int y, int max_width,
+                                  int line_height, int fontsz, int max_lines) {
+    if (!text || !*text) return;
+
+    char buf[512];
+    strncpy(buf, text, sizeof(buf) - 1);
+    buf[sizeof(buf) - 1] = '\0';
+
+    int cur_y = y;
+    int lines = 0;
+    char line[128] = "";
+    char word[96];
+    char *p = buf;
+
+    while (*p && lines < max_lines) {
+        // Skip leading spaces
+        while (*p == ' ' || *p == '\t' || *p == '\r') p++;
+        if (!*p) break;
+
+        // Handle explicit newline: flush current line
+        if (*p == '\n') {
+            if (line[0] != '\0') {
+                fb_draw_text(fb, face, line, x, cur_y, fontsz);
+                cur_y += line_height;
+                lines++;
+                line[0] = '\0';
+            } else {
+                cur_y += line_height;
+                lines++;
+            }
+            p++;
+            continue;
+        }
+
+        // Extract next word
+        int wlen = 0;
+        while (*p && *p != ' ' && *p != '\t' && *p != '\n' && *p != '\r'
+               && wlen < (int)sizeof(word) - 1) {
+            word[wlen++] = *p++;
+        }
+        word[wlen] = '\0';
+        if (wlen == 0) continue;
+
+        // Try appending word to current line
+        char trial[192];
+        if (line[0] == '\0') {
+            snprintf(trial, sizeof(trial), "%s", word);
+        } else {
+            snprintf(trial, sizeof(trial), "%s %s", line, word);
+        }
+
+        if (fb_get_text_width(face, trial, fontsz) > max_width && line[0] != '\0') {
+            // Doesn't fit: flush current line, start new line with word
+            fb_draw_text(fb, face, line, x, cur_y, fontsz);
+            cur_y += line_height;
+            lines++;
+            if (lines >= max_lines) break;
+            snprintf(line, sizeof(line), "%s", word);
+        } else {
+            snprintf(line, sizeof(line), "%s", trial);
+        }
+    }
+
+    if (line[0] != '\0' && lines < max_lines) {
+        fb_draw_text(fb, face, line, x, cur_y, fontsz);
+    }
+}
+
+void generate_notes_display(Framebuffer *fb, DisplayConfig *cfg, FT_Face face) {
+    fb_init(fb);
+    int y = 16;
+
+    fb_draw_text(fb, face, "NOTES", 2, y, 14); y += 20;
+
+    const char *txt = cfg->notes[0] ? cfg->notes : "(no notes configured)";
+    fb_draw_wrapped_text(fb, face, txt, 2, y, WIDTH - 4, 13, 11, 7);
+
+    draw_battery_corner(fb, face, cfg);
 }
 
 void print_usage(const char *prog) {
@@ -230,6 +542,20 @@ void print_usage(const char *prog) {
     fprintf(stderr, "  -h HOST   Hostname\n");
     fprintf(stderr, "  -q        Show QR code (default: show logo)\n");
     fprintf(stderr, "  -u        Convert text to UPPERCASE\n");
+    fprintf(stderr, "  -m MODE   Screen mode (0=default, 1=stats, 2=network, 3=wireguard)\n");
+    fprintf(stderr, "  -U STR    Uptime (mode 1)\n");
+    fprintf(stderr, "  -R STR    RAM usage (mode 1)\n");
+    fprintf(stderr, "  -L STR    Load average (mode 1)\n");
+    fprintf(stderr, "  -T STR    Temperature (mode 1)\n");
+    fprintf(stderr, "  -I STR    WAN IP (mode 2)\n");
+    fprintf(stderr, "  -G STR    Signal strength (mode 2)\n");
+    fprintf(stderr, "  -X STR    RX bytes (mode 2)\n");
+    fprintf(stderr, "  -Y STR    TX bytes (mode 2)\n");
+    fprintf(stderr, "  -C NUM    Connected WiFi clients (mode 2)\n");
+    fprintf(stderr, "  -W STR    WireGuard status (mode 3)\n");
+    fprintf(stderr, "  -H STR    WireGuard handshake age (mode 3)\n");
+    fprintf(stderr, "  -D STR    WireGuard RX bytes (mode 3)\n");
+    fprintf(stderr, "  -E STR    WireGuard TX bytes (mode 3)\n");
 }
 
 
@@ -247,7 +573,7 @@ int main(int argc, char *argv[]) {
     };
     
     int opt;
-    while ((opt = getopt(argc, argv, "b:cn:t:s:p:h:qu")) != -1) {
+    while ((opt = getopt(argc, argv, "b:cn:t:s:p:h:qum:U:R:L:T:I:G:g:X:Y:C:W:H:a:D:E:N:")) != -1) {
         switch (opt) {
             case 'b': cfg.battery = atoi(optarg); break;
             case 'c': cfg.charging = 1; break;
@@ -258,6 +584,23 @@ int main(int argc, char *argv[]) {
             case 'h': strncpy(cfg.hostname, optarg, 31); break;
             case 'q': cfg.show_qr = 1; break;
             case 'u': cfg.uppercase = 1; break;
+            case 'm': cfg.mode = atoi(optarg); break;
+            case 'U': strncpy(cfg.uptime, optarg, 15); break;
+            case 'R': strncpy(cfg.ram, optarg, 15); break;
+            case 'L': strncpy(cfg.load, optarg, 15); break;
+            case 'T': strncpy(cfg.temp, optarg, 7); break;
+            case 'I': strncpy(cfg.wan_ip, optarg, 19); break;
+            case 'G': strncpy(cfg.signal, optarg, 11); break;
+            case 'g': cfg.signal_bars = atoi(optarg); break;
+            case 'X': strncpy(cfg.rx, optarg, 11); break;
+            case 'Y': strncpy(cfg.tx, optarg, 11); break;
+            case 'C': cfg.clients = atoi(optarg); break;
+            case 'W': strncpy(cfg.wg_status, optarg, 11); break;
+            case 'H': strncpy(cfg.wg_handshake, optarg, 11); break;
+            case 'a': strncpy(cfg.wg_uptime, optarg, 15); break;
+            case 'D': strncpy(cfg.wg_rx, optarg, 11); break;
+            case 'E': strncpy(cfg.wg_tx, optarg, 11); break;
+            case 'N': strncpy(cfg.notes, optarg, sizeof(cfg.notes) - 1); break;
             default:
                 print_usage(argv[0]);
                 return 1;
@@ -292,7 +635,16 @@ int main(int argc, char *argv[]) {
     }
     
     Framebuffer fb;
-    generate_display(&fb, &cfg, face);
+    switch (cfg.mode) {
+        case 1: generate_stats_display(&fb, &cfg, face); break;
+        case 2: generate_network_display(&fb, &cfg, face); break;
+        case 3: generate_wireguard_display(&fb, &cfg, face); break;
+        case 4: generate_wifi_display(&fb, &cfg, face); break;
+        case 5: generate_notes_display(&fb, &cfg, face); break;
+        default: generate_display(&fb, &cfg, face); break;
+    }
+
+    fb_rotate_180(&fb);
     
     fwrite(fb.data, sizeof(uint16_t), WIDTH * HEIGHT, stdout);
     


### PR DESCRIPTION
## Summary
Major overhaul of the router display system with 6 screen modes (expanded from 1), visual icons, 180° display rotation, and improved UX.

## Changes
Display Rotation
180° framebuffer rotation: Added fb_rotate_180() to correct display orientation (flips both axes) - because this showed wrong on some (my) device - now its correct way up!

<img width="785" height="1122" alt="Screenshot 2026-04-23 at 16 00 58" src="https://github.com/user-attachments/assets/eddf5c90-0369-48d7-8396-72dd0c451d38" />

## Screen Modes (Expanded from 1 to 6)
Before: only 1 screen with QR code and Operator name + basic battery info
After (6 screens):
<img width="400" height="429" alt="1" src="https://github.com/user-attachments/assets/b8758dc1-57eb-4600-ad3d-7e401f39fefb" />
<img width="400" height="429" alt="2" src="https://github.com/user-attachments/assets/ef39070b-6213-4611-9865-c9000d20b6ca" />
<img width="400" height="429" alt="3" src="https://github.com/user-attachments/assets/9815a19f-1d41-490a-9ddf-e6d789b72e48" />
<img width="400" height="429" alt="4" src="https://github.com/user-attachments/assets/2228ca87-c970-402c-a7c4-fdc72fe07487" />
<img width="400" height="429" alt="5" src="https://github.com/user-attachments/assets/6c593654-5828-4b1c-9923-ba30e3e6d15f" />
<img width="400" height="429" alt="6" src="https://github.com/user-attachments/assets/76decca4-8de1-471a-9311-8d643215bf83" />

Mode 0 — Default: QR code (when WiFi up), signal bars, operator (truncated), network type, hostname (truncated), battery icon with %
Mode 1 — Stats: System uptime, RAM usage, CPU load, temperature
Mode 2 — Network: WAN IP, signal bars with dB/%, download/upload speeds, connected clients
Mode 3 — VPN: WireGuard status, latest handshake age, system uptime, download/upload transfer
Mode 4 — WiFi: SSID (auto-shrinks if long), password, connected client count
Mode 5 — Notes: Custom text display with word-wrap (up to 7 lines). Reads from UCI system.notes → /etc/display_notes → system.description (fallback chain)

## Power Button Behavior

**Short press**: Cycles screens (default → stats → network → VPN → WiFi → notes → default)
**Hold 5s+**: Shutdown (changed from double-press)
**Auto-reset**: Returns to default screen after 15s of inactivity

## Visual Icons
Battery icon: Color-coded fill (green >50%, yellow >20%, red <20%), charging bolt overlay when plugged in
Signal bars: 4-bar indicator (derived from RSSI dBm or signal quality %)
 
## Signal bars before operator
Operator truncates with .. when too long to preserve 4G on right

## Tuning
Edit /etc/rc.button/power on device:

LONG_PRESS_SEC=5 — seconds to hold for shutdown
RESET_TIMEOUT=15 — idle seconds before returning to default screen
NUM_MODES=6 — number of screens to cycle through
