### PR TITLE
Add UF02 sysupgrade support

### DIFF
--- a/msm89xx/image/msm8916.mk
+++ b/msm89xx/image/msm8916.mk
@@ -44,6 +44,7 @@ define Device/generic-uf02
   $(Device/msm8916)
   DEVICE_VENDOR := Generic
   DEVICE_MODEL := UF02 (250605 V0S)
+  SUPPORTED_DEVICES := uf02,250605v0s
   FILESYSTEMS := squashfs
   DEVICE_PACKAGES := wpad-basic-wolfssl rmtfs uci-usb-gadget \
                      block-mount f2fs-tools \


### PR DESCRIPTION
## Summary

Adds sysupgrade support metadata for the Generic UF02 device.

PR #25 added sysupgrade image generation and upgrade handling, but only declared `SUPPORTED_DEVICES` for `yiming-uz801v3`. This adds the equivalent board compatibility string for UF02:

```make
SUPPORTED_DEVICES := uf02,250605v0s
```

## Why

`platform_check_image()` validates the sysupgrade tar against the running board name. The UF02 DTS declares:

```dts
compatible = "uf02,250605v0s", "qcom,msm8916";
```

Without this metadata, the UF02 sysupgrade image may build but fail validation on-device.

## Testing

- Built locally for `generic-uf02` using `diffconfig_uf02`.
- Intended follow-up test: flash/run a UF02 image that already contains #25, then run sysupgrade with the generated UF02 `*-squashfs-sysupgrade.bin`.
