### PR TITLE
fix(sysupgrade): remove platform_pre_upgrade and simplify image validation

### DIFF
--- a/msm89xx/base-files/lib/upgrade/platform.sh
+++ b/msm89xx/base-files/lib/upgrade/platform.sh
@@ -7,17 +7,8 @@ RAMFS_COPY_DATA="/lib/functions.sh /lib/upgrade/common.sh /lib/upgrade/fwtool.sh
 
 platform_check_image() {
     local fw_image="$1"
-    local boardname
-    
-    read boardname </tmp/sysinfo/board_name
-    boardname=${boardname//-/}
-    boardname=${boardname//,/-}
 
-    # Must be a tar archive
-    local control_len=$( (tar xf $fw_image sysupgrade-$boardname/CONTROL -O | wc -c) 2> /dev/null)
-
-    # check if valid sysupgrade tar archive
-    if [ "$control_len" = "0" ]; then
+    if ! tar tf "$fw_image" | grep -q 'sysupgrade-.*/CONTROL'; then
         echo "Invalid sysupgrade file: $fw_image"
         return 1
     fi
@@ -47,9 +38,4 @@ platform_do_upgrade() {
         dd of="$rootfs_part" bs=4096 conv=fsync
 
     sync
-}
-
-platform_pre_upgrade() {
-    rm -fr /overlay/upper/* /overlay/upper/.* 2>/dev/null
-    [ -f "$UPGRADE_BACKUP" ] && cp -f "$UPGRADE_BACKUP" "/overlay/upper/$BACKUP_FILE" 2>/dev/null
 }

--- a/msm89xx/base-files/lib/upgrade/platform.sh
+++ b/msm89xx/base-files/lib/upgrade/platform.sh
@@ -8,7 +8,7 @@ RAMFS_COPY_DATA="/lib/functions.sh /lib/upgrade/common.sh /lib/upgrade/fwtool.sh
 platform_check_image() {
     local fw_image="$1"
 
-    if ! tar tf "$fw_image" | grep -q 'sysupgrade-.*/CONTROL'; then
+    if ! tar tf "$fw_image" 2>/dev/null | grep -qE '^(\./)?sysupgrade-[^/]+/CONTROL$'; then
         echo "Invalid sysupgrade file: $fw_image"
         return 1
     fi


### PR DESCRIPTION
The `platform_pre_upgrade()` implementation is causing several issues:
1. `.*` matches `.` and `..` so running  `rm -fr /overlay/upper/.*` will delete `/overlay`, which is dangerous on a live system.
2. This also wipes all user modifications prior to flashing, effectively forcing a factory reset even when the user requested to keep settings (SAVE_CONFIG=1).
3. The `$BACKUP_FILE` variable is undefined in OpenWrt's sysupgrade execution environment
4. OpenWrt's `/sbin/sysupgrade` natively handles overlay formatting (via fstools/jffs2reset on clean upgrades) and configuration backup/restore (via /tmp/sysupgrade.tgz in RAMFS), so, mhh, why even running `rm -rf` at all?
---
`platform_check_image()` was simplified. Replaced fragile manual string manipulation with standard tar content verification.

The previous string transformation logic (${boardname//-/} and ${boardname//,/-}) attempted to predict the folder name inside the tar. If naming conventions inside the generated `sysupgrade.bin` slightly differed, tar xf failed and rejected valid images with an "Invalid sysupgrade file" error.

Board compatibility checking is already handled automatically by OpenWrt's fwtool because REQUIRE_IMAGE_METADATA=1 is set alongside SUPPORTED_DEVICES in the target Makefile.